### PR TITLE
Update types in CampaignPosts request builder and add Tiers to Post model

### DIFF
--- a/PatreonClient/Models/Attributes/Post.cs
+++ b/PatreonClient/Models/Attributes/Post.cs
@@ -16,4 +16,5 @@ public class Post
     [JsonPropertyName("embed_url")] public string EmbedUrl { get; set; }
     [JsonPropertyName("app_id")] public int? AppId { get; set; }
     [JsonPropertyName("app_status")] public string AppStatus { get; set; }
+    [JsonPropertyName("tiers")] public List<long>? Tiers { get; set; }
 }

--- a/PatreonClient/PatreonRequestBuilder.cs
+++ b/PatreonClient/PatreonRequestBuilder.cs
@@ -49,10 +49,10 @@ public static class PatreonRequestBuilder
         return new(builder.BuildUrl());
     }
 
-    public static PatreonRequest<string, PatreonCollectionResponse<Member, MemberRelationships>> CampaignPosts(Action<IFieldSelector<Member, MemberRelationships>> action)
+    public static PatreonRequest<string, PatreonCollectionResponse<Post, PostRelationships>> CampaignPosts(Action<IFieldSelector<Post, PostRelationships>> action)
     {
         var builder = new RequestBuilder("/api/oauth2/v2/campaigns/{0}/posts");
-        action(new FieldSelector<Member, MemberRelationships>(builder));
+        action(new FieldSelector<Post, PostRelationships>(builder));
         return new(builder.BuildUrl());
     }
 }


### PR DESCRIPTION
CampaignPosts in PatreonRequestBuilder appeared to have a copy/paste error and Post attribute model was missing Tiers property consisting of an array of integers IDs. Not much experience with Github PRs, so please forgive if I did something incorrectly.