### PR TITLE
Added extension method and documentation for authenticating patrons

### DIFF
--- a/PatreonClient/PatreonHttpClientExtensions.cs
+++ b/PatreonClient/PatreonHttpClientExtensions.cs
@@ -7,7 +7,7 @@ namespace PatreonClient;
 
 public static class PatreonHttpClientExtensions
 {
-    public static async Task<Tokens> RefreshAccessTokenAsync(
+    public static Task<Tokens> RefreshAccessTokenAsync(
         this HttpClient client,
         string clientId,
         string clientSecret,
@@ -20,6 +20,27 @@ public static class PatreonHttpClientExtensions
                   $"&client_id={clientId}" +
                   $"&client_secret={clientSecret}";
 
+        return RequestTokens(client, uri);
+    }
+
+    public static Task<Tokens> GenerateAccessTokenAsync(
+        this HttpClient client,
+        string clientId,
+        string clientSecret,
+        string oneTimeCode
+    )
+    {
+        var uri = "https://www.patreon.com/api/oauth2/token" +
+                  "?grant_type=authorization_code" +
+                  $"&code={oneTimeCode}" +
+                  $"&client_id={clientId}" +
+                  $"&client_secret={clientSecret}";
+
+        return RequestTokens(client, uri);
+    }
+
+    private static async Task<Tokens> RequestTokens(HttpClient client, string uri)
+    {
         var responseMessage = await client.PostAsync(uri, null);
         if (!responseMessage.IsSuccessStatusCode) throw new FailedToRefreshAccessToken();
         

--- a/README.md
+++ b/README.md
@@ -185,3 +185,24 @@ var campaignMembersRequest = PatreonRequestBuilder.CampaignMembers(
           .ThenInclude(x => x.Benefits)
 );
 ```
+
+## Authenticating a Patron
+
+This example requires that the user is first directed to the following URL 
+(usually through a "Log in with Patreon" button).
+```
+https://www.patreon.com/oauth2/authorize?response_type=code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}
+```
+Where CLIENT_ID is the ID of the creator's client app and REDIRECT_URI is the URI Patreon will call once the user 
+is authenticated.  
+See https://docs.patreon.com/#step-1-registering-your-client for more information.
+
+The `code` can then be extracted from the query string of the redirect URI and processed as follows to generate
+the usual `Tokens` object used in other examples. This token will have fewer permissions than your creator token,
+so it should only be used for actions specific to this user.
+
+```csharp
+using var httpClient = new HttpClient();
+var tokens = httpClient.GenerateAccessTokenAsync(clientId, clientSecret, code);
+// Store the tokens in a way that your PatreonTokens implementation will read from
+```


### PR DESCRIPTION
Firstly, I'd just like to thank you and the contributors for a wonderful repository. The Patreon API is really not well documented, and requires a lot of strange URL sections, so having a fluent .NET API to interface with it is incredibly nice.

One thing I couldn't find any support for was the ability to authenticate a patron. The way this process works (and please correct me if there's a better way) is that the user is directed to the following URL by some means, usually a login button of sorts in the client application:
```
https://www.patreon.com/oauth2/authorize?response_type=code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}
```
Where CLIENT_ID is the ID of the creator's client app and REDIRECT_URI is the URI Patreon will call once the user is authenticated, passing back a code to the client.

The `code` is then extracted from the redirect URI. This code is a one-time thing. I'm unsure if it's compatible with `AccessToken` in something like `AccessTokenOnly` but I would assume not. This code is passed to the following URL which returns a `PatreonClient.Tokens` response.
```
https://www.patreon.com/api/oauth2/token?code={CODE}&grant_type=authorization_code&client_id={CLIENT_ID}&client_secret={CLIENT_SECRET}
```

After getting that response back, it's business as usual. The `Tokens` response can be stored somewhere (probably somewhere that the consumer's `PatreonTokens` implementation would call from), and used in a `Patreon` to perform requests and have the tokens refreshed as needed. In my case, all I do is use it once to call `PatreonRequestBuilder.Identity` with the `Memberships` include so I can grab the membership ID to store on the server to check the patron's tiers periodically from the creator account to enable benefits accordingly.

I am proposing that this process is integrated into this library in a way that fits with how things work currently. It won't fit with the `Patreon` class itself as that requires that the tokens can be retrieved as needed from the `PatreonTokens` implementation, so I have added an extension method to `HttpClient` much in the same way as `RefreshAccessTokenAsync`. Since the one-time code comes from a callback, it can't really be implemented in `PatreonTokens.GetTokensAsync` which is why I have used an extension method rather than creating a default implementation of `PatreonTokens`. The README has been updated to show usage as well.